### PR TITLE
Mw  breadcrumbs

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -704,6 +704,34 @@ input:checked + .slider:before {
   border-radius: 50%;
 }
 
+
+/* CSS for product details page breadcrumbs */
+.breadcrumbs {
+  padding: 10px 18px;
+  background-color: rgb(238, 238, 238);
+  justify-content: center;
+  text-align: center;
+}
+
+.breadcrumbs>li {
+  display: inline-block;
+}
+.breadcrumbs>li>a {
+color: var(--dark-grey);
+  text-decoration: none;
+}
+
+.breadcrumbs>li>a:hover {
+  text-decoration: underline;
+  background-color: var(--primary-color);
+  padding: 0.3em;
+}
+
+.breadcrumbs li+li:before {
+  padding: 4px;
+  content: "/";
+}
+
 /******************** START OF MEDIUM & UP FORM CSS FOR CHECKOUT PAGE *******************************/
 form input.submitBtn {
   /* margin: 0 0 0 2%; */

--- a/src/js/productDetails.js
+++ b/src/js/productDetails.js
@@ -12,10 +12,19 @@ export default class ProductDetails {
 
   async init() {
     this.product = await this.dataSource.findProductById(this.productId);
-    //console.log(this.product);
+    console.log(this.product);
     //console.log(this.product.Count);
 
     this.renderProductDetails();
+
+    // Put the path into the breadcrumbs
+    document.querySelector(".product-breadcrumb")
+      .innerHTML = `${this.product.Category.charAt(0).toUpperCase() + this.product.Category.slice(1)}`
+      let hrefPath = `../product-listing?category=${this.product.Category}`;
+    document.querySelector(".product-breadcrumb").href = hrefPath;
+    // product-listing?category=hammocks
+
+
 
     // code to add items to the cart
     let addButt = document.getElementById("addToCart");

--- a/src/js/productList.js
+++ b/src/js/productList.js
@@ -23,13 +23,14 @@ export default class ProductList {
         a.NameWithoutBrand.localeCompare(b.NameWithoutBrand)
       );
     }
-    // document.querySelector(".products>h2").innerHTML += `: ${(
-    //   this.category.charAt(0).toUpperCase() + this.category.slice(1)
-    // ).replace("-b", " B")}`;
 
+  
     document.querySelector(".products>h2").innerHTML = `Top Products: ${(
       this.category.charAt(0).toUpperCase() + this.category.slice(1)
     ).replace("-b", " B")}`;
+
+
+    document.querySelector(".product-breadcrumb").innerHTML = `${this.category.charAt(0).toUpperCase() + this.category.slice(1)} -> ${list.length}`
 
     //render the list
     this.renderList(list)

--- a/src/js/productList.js
+++ b/src/js/productList.js
@@ -30,7 +30,7 @@ export default class ProductList {
     ).replace("-b", " B")}`;
 
 
-    document.querySelector(".product-breadcrumb").innerHTML = `${this.category.charAt(0).toUpperCase() + this.category.slice(1)} -> ${list.length}`
+    document.querySelector(".product-breadcrumb").innerHTML = `${this.category.charAt(0).toUpperCase() + this.category.slice(1)} (${list.length} items)`
 
     //render the list
     this.renderList(list)

--- a/src/product-listing/index.html
+++ b/src/product-listing/index.html
@@ -8,6 +8,10 @@
   </head>
   <body>
     <header class="divider" id="main-header"></header>
+    <ul class="breadcrumbs">
+      <li><a href="../index.html">Home</a></li>
+      <li><a class="product-breadcrumb" href="#"></a></li>
+    </ul>
     <main class="divider">
       <section class="mission">
         <p>No wonder we are a mess!</p>

--- a/src/product_pages/product-details.html
+++ b/src/product_pages/product-details.html
@@ -9,6 +9,10 @@
   </head>
   <body>
     <header class="divider" id="main-header"></header>
+    <ul class="breadcrumbs">
+      <li><a href="../index.html">Home</a></li>
+      <li><a class="product-breadcrumb" href="#"></a></li>
+    </ul>
     <main class="divider">
       <section class="product-detail">
         <h3></h3>


### PR DESCRIPTION
This PR is a branch made from the previous PR @ #39 . Please ensure that request is completed first.
This adds in breadcrumbs in the product details pages. On the main product list page, it will show breadcumbs with the homepage, and the product category (including how many total products of that type there are). The product details page will show the user the home page and the category page for the product they are viewing.

- [x] ensure that the link from the product listing page takes you to the home page and the other one doesn't take you anywhere
- [x] ensure that the links in the product details page takes you to the homepage, and the category page for the product you are viewing (eg, a tent's page will take you back to the tensts.